### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -21,7 +21,7 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 
 # In-memory activity database
 activities = {
-    ,
+    
         "Soccer Team": {
             "description": "Team practices and competitive matches focused on fitness and teamwork",
             "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
@@ -57,7 +57,7 @@ activities = {
             "schedule": "Mondays, 3:30 PM - 5:00 PM",
             "max_participants": 20,
             "participants": ["elijah@mergington.edu", "harper@mergington.edu"]  
-        }
+        },
     "Chess Club": { 
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -106,3 +106,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+# New endpoint: Unregister a participant from an activity
+from fastapi import Query
+
+@app.delete("/activities/{activity_name}/unregister")
+def unregister_from_activity(activity_name: str, email: str = Query(...)):
+    """Remove a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    activity = activities[activity_name]
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Participant not found")
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,6 +4,25 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  function renderParticipants(participants, activityName) {
+    if (!participants.length) {
+      return '<div class="participant-empty">No participants yet</div>';
+    }
+    return participants
+      .map((participant) =>
+        `<div class="participant-row">
+          <span class="participant-email">${participant}</span>
+          <button class="delete-participant" title="Remove participant" data-activity="${encodeURIComponent(activityName)}" data-email="${encodeURIComponent(participant)}">
+            <svg width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="10" cy="10" r="10" fill="#ffebee"/>
+              <path d="M6 6l8 8M14 6l-8 8" stroke="#c62828" stroke-width="2" stroke-linecap="round"/>
+            </svg>
+          </button>
+        </div>`
+      )
+      .join("");
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
@@ -12,6 +31,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -25,6 +45,12 @@ document.addEventListener("DOMContentLoaded", () => {
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title">Current Participants</p>
+              <div class="participants-list">
+                ${renderParticipants(details.participants, name)}
+              </div>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +88,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +105,29 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  // Handle participant delete
+  activitiesList.addEventListener("click", async (event) => {
+    const btn = event.target.closest(".delete-participant");
+    if (!btn) return;
+    const activity = decodeURIComponent(btn.getAttribute("data-activity"));
+    const email = decodeURIComponent(btn.getAttribute("data-email"));
+    if (!activity || !email) return;
+    if (!confirm(`Remove ${email} from ${activity}?`)) return;
+    try {
+      const response = await fetch(`/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`, {
+        method: "DELETE",
+      });
+      const result = await response.json();
+      if (response.ok) {
+        fetchActivities();
+      } else {
+        alert(result.detail || "Failed to remove participant.");
+      }
+    } catch (error) {
+      alert("Failed to remove participant. Please try again.");
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,72 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid #d7e2f3;
+  background: linear-gradient(180deg, #f9f9f9 0%, #f2f6ff 100%);
+  border-radius: 4px;
+}
+
+.participants-title {
+  margin-bottom: 8px;
+  font-weight: bold;
+  color: #1a237e;
+}
+
+
+.participants-list {
+  margin: 0;
+  padding: 0;
+}
+
+.participant-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.participant-row:last-child {
+  border-bottom: none;
+}
+
+.participant-email {
+  color: #1f2937;
+  font-size: 15px;
+  word-break: break-all;
+}
+
+.delete-participant {
+  background: none;
+  border: none;
+  padding: 2px;
+  margin-left: 10px;
+  cursor: pointer;
+  border-radius: 50%;
+  transition: background 0.2s;
+  display: flex;
+  align-items: center;
+}
+
+.delete-participant:hover {
+  background: #ffebee;
+  box-shadow: 0 0 0 2px #ffcdd2;
+}
+
+.delete-participant svg {
+  display: block;
+}
+
+.participant-empty {
+  list-style: none;
+  margin-left: -20px;
+  color: #6b7280;
+  font-style: italic;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,61 @@
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app
+
+client = TestClient(app)
+
+# Arrange-Act-Assert: Test GET /activities
+def test_get_activities():
+    # Arrange: nothing needed, just client
+    # Act
+    response = client.get("/activities")
+    # Assert
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, dict)
+    assert "Soccer Team" in data
+
+# Arrange-Act-Assert: Test POST /activities/{activity_name}/signup
+def test_signup_for_activity():
+    # Arrange
+    activity = "Soccer Team"
+    email = "testuser@mergington.edu"
+    # Act
+    response = client.post(f"/activities/{activity}/signup?email={email}")
+    # Assert
+    assert response.status_code == 200
+    assert f"Signed up {email} for {activity}" in response.json()["message"]
+    # Clean up: remove test user
+    client.delete(f"/activities/{activity}/unregister?email={email}")
+
+# Arrange-Act-Assert: Test DELETE /activities/{activity_name}/unregister
+def test_unregister_from_activity():
+    # Arrange
+    activity = "Soccer Team"
+    email = "testuser2@mergington.edu"
+    # Add user first
+    client.post(f"/activities/{activity}/signup?email={email}")
+    # Act
+    response = client.delete(f"/activities/{activity}/unregister?email={email}")
+    # Assert
+    assert response.status_code == 200
+    assert f"Unregistered {email} from {activity}" in response.json()["message"]
+
+# Arrange-Act-Assert: Test error on duplicate signup
+def test_signup_duplicate():
+    activity = "Soccer Team"
+    email = "testuser3@mergington.edu"
+    client.post(f"/activities/{activity}/signup?email={email}")
+    response = client.post(f"/activities/{activity}/signup?email={email}")
+    assert response.status_code == 400
+    assert "Student already signed up" in response.json()["detail"]
+    # Clean up
+    client.delete(f"/activities/{activity}/unregister?email={email}")
+
+# Arrange-Act-Assert: Test error on removing non-existent participant
+def test_unregister_nonexistent():
+    activity = "Soccer Team"
+    email = "notfound@mergington.edu"
+    response = client.delete(f"/activities/{activity}/unregister?email={email}")
+    assert response.status_code == 404
+    assert "Participant not found" in response.json()["detail"]


### PR DESCRIPTION
This pull request adds the ability for users to unregister from activities, improves the user interface for managing participants, and introduces automated tests for key API endpoints. The main changes include a new backend endpoint for participant removal, frontend updates to display and manage participants, UI enhancements for participant lists, and the addition of tests to ensure core functionality works as expected.

**Backend functionality:**

* Added a new `DELETE /activities/{activity_name}/unregister` endpoint in `src/app.py` to allow participants to be removed from activities.

**Frontend enhancements:**

* Updated `src/static/app.js` to display a list of current participants for each activity, including a "remove" button for each participant, and to refresh the activity list after signup or removal. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R7-R25) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R48-R53) [[3]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R91) [[4]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R111-R133)
* Improved the activity selection dropdown to always show a default "Select an activity" option.

**User interface improvements:**

* Styled the participants section and delete button in `src/static/styles.css` for better usability and visual clarity.

**Testing:**

* Added `tests/test_app.py` with automated tests for listing activities, signing up, unregistering, duplicate signups, and error handling when removing non-existent participants.

**Minor fixes:**

* Cleaned up the in-memory activity data structure in `src/app.py` to remove a stray comma. [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L24-R24) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L60-R60)